### PR TITLE
Normalize weather inputs and rescale imputation outputs

### DIFF
--- a/HLVAE_main.py
+++ b/HLVAE_main.py
@@ -42,7 +42,11 @@ if __name__ == "__main__":
     if not folder_exists:
         os.makedirs(save_path)
 
-    results_path = os.path.join(save_path , results_path)
+    # ``results_path`` is optional in many configs.  When it is omitted the
+    # argument parser returns ``None`` which causes ``os.path.join`` to raise a
+    # ``TypeError``.  Default to saving results directly inside ``save_path`` if
+    # no subfolder is specified.
+    results_path = os.path.join(save_path, results_path) if results_path else save_path
     gp_model_folder = os.path.join(save_path, gp_model_folder)
     model_params = os.path.join(save_path, model_params)
     folder_exists = os.path.isdir(results_path)

--- a/HL_VAE/read_functions.py
+++ b/HL_VAE/read_functions.py
@@ -54,6 +54,12 @@ def read_data(data_file, miss_file, true_miss_file, types_file, range_file, logv
                 true_miss_mask[missing_positions[:, 0] - 1, missing_positions[:, 1] - 1] = 0   # Indexes in the csv start at 1
         else:
             true_miss_mask = missing_positions  ## Missing file is already in the matrix form
+            if true_miss_mask.shape == (data.shape[1], data.shape[0]):
+                true_miss_mask = true_miss_mask.T
+            elif true_miss_mask.shape != (data.shape[0], data.shape[1]):
+                raise ValueError(
+                    f"True mask shape {true_miss_mask.shape} incompatible with data shape {(data.shape[0], data.shape[1])}"
+                )
 
     # Construct the data matrices
     n_variables = data.shape[1]
@@ -136,6 +142,12 @@ def read_data(data_file, miss_file, true_miss_file, types_file, range_file, logv
                 miss_mask[missing_positions[:, 0] - 1, missing_positions[:, 1] - 1] = 0   # Indexes in the csv start at 1
         else:
             miss_mask = missing_positions  ## Missing file is already in the matrix form
+            if miss_mask.shape == (n_variables, np.shape(data)[0]):
+                miss_mask = miss_mask.T
+            elif miss_mask.shape != (np.shape(data)[0], n_variables):
+                raise ValueError(
+                    f"Mask shape {miss_mask.shape} incompatible with data shape {(np.shape(data)[0], n_variables)}"
+                )
     miss_mask = miss_mask * true_miss_mask
 
 

--- a/impute_weather_data.py
+++ b/impute_weather_data.py
@@ -23,7 +23,10 @@ if __name__ == "__main__":
     hidden_layers = ast.literal_eval(hidden_layers)
 
     # Reconstruct paths using the base 'save_path' for consistency
-    results_path = os.path.join('./results')
+    # ``results_path`` may be omitted in the configuration, in which case it
+    # defaults to ``save_path`` directly.  Avoid ``TypeError`` from
+    # ``os.path.join`` when the argument is ``None``.
+    results_path = os.path.join(save_path, results_path) if results_path else save_path
     gp_model_folder = os.path.join(save_path, gp_model_folder)
     
     # Determine the correct model file to use based on the early_stopping flag
@@ -52,8 +55,8 @@ if __name__ == "__main__":
 
     # --- 3. Load Trained VAE Model ---
     # The VAE parameters are now available as local variables
-    nnet_model = HLVAE([dataset.cov_dim_ext, hidden_layers, latent_dim, hidden_layers, y_dim], dataset.types_info,
-                       dataset.n_variables, vy_init=[vy_init_real, vy_init_pos], logvar_network=logvar_network, conv=conv_hivae).to(
+    nnet_model = HLVAE([test_dataset.cov_dim_ext, hidden_layers, latent_dim, hidden_layers, y_dim], test_dataset.types_info,
+                       test_dataset.n_variables, vy_init=[vy_init_real, vy_init_pos], logvar_network=logvar_network, conv=conv_hivae).to(
         device).to(torch.float64)
     try:
         nnet_model.load_state_dict(torch.load(model_params, map_location=lambda storage, loc: storage))
@@ -64,11 +67,11 @@ if __name__ == "__main__":
     # --- 4. Perform Imputation ---
     with torch.no_grad():
         batch = next(iter(dataloader))
-        batch_Y = batch["Y"].to(device).double()
+        batch_Y = batch["digit"].to(device).double()
         mask_Y = batch["mask"].to(device)
-        batch_X = batch["X"].to(device).double()
+        param_mask = batch["param_mask"].to(device)
 
-        p_samples, _, _, _, _, _, _, _ = vae(data=batch_Y, mask=mask_Y, param_mask=mask_Y, types_info=test_dataset.types_info, X_list=[batch_X])
+        p_samples, _, _, _, _, _, _, _ = nnet_model(data=batch_Y, mask=mask_Y, param_mask=param_mask, types_info=test_dataset.types_info)
         
         reconstructed_data = p_samples['x']
         if isinstance(reconstructed_data, list):
@@ -84,6 +87,18 @@ if __name__ == "__main__":
         imputed_np[:, pos_cols] = np.exp(imputed_np[:, pos_cols]) - EPS
         print(f"Applied inverse transformation to {len(pos_cols)} positive columns.")
 
+    # Inverse min-max scaling using training ranges
+    ranges_df = pd.read_csv(os.path.join(data_source_path, csv_range_file))
+    ground_truth_np = test_dataset.Y.cpu().numpy()
+    for col_idx, col in enumerate(test_dataset.Y_df.columns):
+        min_val = ranges_df.loc[ranges_df['variable'] == col, 'min'].values[0]
+        max_val = ranges_df.loc[ranges_df['variable'] == col, 'max'].values[0]
+        scale = max_val - min_val
+        imputed_np[:, col_idx] = imputed_np[:, col_idx] * scale + min_val
+        ground_truth_np[:, col_idx] = ground_truth_np[:, col_idx] * scale + min_val
+        if col.lower() in ['rrr24', 'q']:
+            imputed_np[:, col_idx] = np.clip(imputed_np[:, col_idx], 0, max_val)
+
     imputed_df = pd.DataFrame(imputed_np, columns=test_dataset.Y_df.columns)
     output_file = os.path.join(results_path, "imputed_weather_test_data.csv")
     imputed_df.to_csv(output_file, index=False)
@@ -95,7 +110,6 @@ if __name__ == "__main__":
     print("\nCreating a comparison file for missing values...")
 
     miss_mask = test_dataset.mask.cpu().numpy() == 0
-    ground_truth_np = test_dataset.Y.cpu().numpy()
     column_names = test_dataset.Y_df.columns
 
     comparison_data = []


### PR DESCRIPTION
## Summary
- Min-max normalize tmax, tmin, tm, rrr24, and Q when preparing datasets
- Save normalization ranges for later inverse-scaling
- Rescale model imputations back to original units and clamp rrr24/Q to non-negative values
- Gracefully handle optional results_path in training and imputation scripts

## Testing
- `python script/create_input_datasets.py`
- `python impute_weather_data.py --f config/weatherconfig.txt`


------
https://chatgpt.com/codex/tasks/task_e_68c66301ccf48322a5c2f90376bb0e5b